### PR TITLE
[do-not-merge] Improve API endpoint documentation (Fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Mozilla Change Integration Service PersonAPI
 
-This is a proof of concept.  Not ready for use outside of Core IAM team.
-
 __Description:__
 
 This API will return profiles as they are stored in the dynamodb table.  Currently only two scopes for non
@@ -18,11 +16,12 @@ mozillaiam/docker-sls:latest \
 ```
 
 # Locations
+
 Highly subject to change.
 
-__Prod__ : https://uhbz4h3wa8.execute-api.us-west-2.amazonaws.com/prod/profile/
+__Prod__ : https://uhbz4h3wa8.execute-api.us-west-2.amazonaws.com/prod/
 
-__Dev__ : https://295w5a6tu1.execute-api.us-west-2.amazonaws.com/dev/profile/
+__Dev__ : https://295w5a6tu1.execute-api.us-west-2.amazonaws.com/dev/
 
 __Scopes Supported:__
   - read:email
@@ -31,6 +30,27 @@ __Scopes Supported:__
 # Calling the Profile Endpoint
 
 1. Get an access token from the OAuth authorizer (i.e. https://auth.mozilla.auth0.com/oauth/token) with the required scopes for your query. This token is valid 24h.
-2. Use the access token to retrieve data from the API as such: `curl --request GET --url https://295w5a6tu1.execute-api.us-west-2.amazonaws.com/dev/profile/ad%7CMozilla-LDAP-Dev%7Ckangtest --header 'authorization: Bearer YOURBEARERTOKENHERE'`
 
-> Make sure you urlencode the authzero_id (`user.user_id`).
+- Out of browser?
+- OAuth dance?
+- scopes?
+
+2. Use the access token to retrieve data from the API.
+
+```HTTP
+GET /profile/{userid}
+Authorization: Bearer $ACCESS_TOKEN
+
+{
+    ...
+    example ?
+}
+```
+
+> Make sure you urlencode the user id (`user.user_id`).
+
+Example:
+
+```
+curl --request GET --url https://295w5a6tu1.execute-api.us-west-2.amazonaws.com/dev/profile/ad%7CMozilla-LDAP-Dev%7Ckangtest --header 'authorization: Bearer N0-hV2n33aCiXYZ'`
+```


### PR DESCRIPTION
WIP

Fixes #2 

* [x] Remove mention of POC
* [x] Improve endpoint doc
* [ ] Better documentation of obtention of Access token
* [ ] Add documentation about how to get authorized to obtain user info (returns `{"message":"Unauthorized"}` by default)