### PR TITLE
fix retrieval of ldap.json.xz to use full profile file

### DIFF
--- a/person-api/config.dev.yml
+++ b/person-api/config.dev.yml
@@ -10,4 +10,4 @@ CERTIFICATE_NAME: person-api.sso.allizom.org
 ZONE_ID: Z1TD6NP912K738
 TEMPORARY_LDAP_DIFF_BUCKET: dev-cis-ldap2s3-publisher-data
 TEMPORARY_LDAP_S3_REGION: us-east-1
-TEMPORARY_LDAP_JSON_FILE: ldap.json.xz
+TEMPORARY_LDAP_JSON_FILE: ldap-full-profile.json.xz

--- a/person-api/config.prod.yml
+++ b/person-api/config.prod.yml
@@ -10,4 +10,4 @@ CERTIFICATE_NAME: person-api.sso.mozilla.com
 ZONE_ID: Z3QSLLEQC9DYUS
 TEMPORARY_LDAP_DIFF_BUCKET: cis-ldap2s3-publisher-data
 TEMPORARY_LDAP_S3_REGION: us-east-1
-TEMPORARY_LDAP_JSON_FILE: ldap.json.xz
+TEMPORARY_LDAP_JSON_FILE: ldap-full-profile.json.xz

--- a/person-api/jobs.py
+++ b/person-api/jobs.py
@@ -74,10 +74,15 @@ def populate_public_table(event=None, context={}):
     logger.info('Pulling in temporary data from LDAP.')
     ldap_people = ldapfroms3.People().all
 
-    for email in ldap_people:
-        public_user_data = {
-            'user_email': email.lower(),
-            'connection_method': 'ad'
-        }
-        res = pdt.create_or_update(public_user_data)
-        logger.info('Result of storage is: {}'.format(res))
+    for k, v in ldap_people:
+        email = v.get('primaryEmail')
+
+        if email is not None:
+            public_user_data = {
+                'user_email': email.lower(),
+                'connection_method': 'ad'
+            }
+            res = pdt.create_or_update(public_user_data)
+            logger.info('Result of storage is: {}'.format(res))
+        else:
+            pass

--- a/person-api/ldapfroms3.py
+++ b/person-api/ldapfroms3.py
@@ -39,6 +39,6 @@ class People(object):
 
         ldap_json = json.loads(
             lzma.open('/tmp/{}'.format(object_key)).read()
-        )
+        ).items()
 
         return ldap_json


### PR DESCRIPTION
Closes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1479804

ldap.json.xz stopped being actively updated in May in favor the full profile file.  This converts the data structure used to populate the connection endpoint and sets a setting to use this file instead.

Note:  This is already in dev and will deploy to production on merge.